### PR TITLE
Dev/sata imx6q sabrelite

### DIFF
--- a/patch.sh
+++ b/patch.sh
@@ -60,6 +60,7 @@ imx () {
 	${git} "${DIR}/patches/imx/0001-ARM-dts-imx6q-enable-snvs-lp-rtc.patch"
 	${git} "${DIR}/patches/imx/0002-ARM-imx-enable-cpufreq-for-imx6q.patch"
 	${git} "${DIR}/patches/imx/0003-ARM-imx-Enable-UART1-for-Sabrelite.patch"
+	${git} "${DIR}/patches/imx/0004-Add-IMX6Q-AHCI-support.patch"
 }
 
 drm () {

--- a/patches/imx/0004-Add-IMX6Q-AHCI-support.patch
+++ b/patches/imx/0004-Add-IMX6Q-AHCI-support.patch
@@ -1,0 +1,122 @@
+From 4e59a76cb57afb19ae28b089c5d13301f7ff5b8e Mon Sep 17 00:00:00 2001
+From: Allen Ibara <allen@zee.aero>
+Date: Tue, 4 Dec 2012 20:44:26 -0800
+Subject: [PATCH] Add IMX6Q AHCI support
+
+Adds device tree node and ahci_platform bits to make AHCI work on sabrelite IMX6Q board.
+
+Signed-off-by: Allen Ibara <allen@zee.aero>
+---
+ arch/arm/boot/dts/imx6q-sabrelite.dts |  5 +++++
+ arch/arm/boot/dts/imx6q.dtsi          |  8 ++++++++
+ drivers/ata/ahci_platform.c           | 29 ++++++++++++++++++++++-------
+ 3 files changed, 35 insertions(+), 7 deletions(-)
+
+diff --git a/arch/arm/boot/dts/imx6q-sabrelite.dts b/arch/arm/boot/dts/imx6q-sabrelite.dts
+index daa2946..3e0b188 100644
+--- a/arch/arm/boot/dts/imx6q-sabrelite.dts
++++ b/arch/arm/boot/dts/imx6q-sabrelite.dts
+@@ -136,6 +136,11 @@
+ 				};
+ 			};
+ 		};
++
++		ahci@0x02200000 { /* AHCI SATA */
++			status = "okay";
++		};
++
+ 	};
+ 
+ 	regulators {
+diff --git a/arch/arm/boot/dts/imx6q.dtsi b/arch/arm/boot/dts/imx6q.dtsi
+index 3025eb6..3afbb88 100644
+--- a/arch/arm/boot/dts/imx6q.dtsi
++++ b/arch/arm/boot/dts/imx6q.dtsi
+@@ -1024,5 +1024,13 @@
+ 				status = "disabled";
+ 			};
+ 		};
++
++		ahci@0x02200000 { /* AHCI SATA */
++			compatible = "fsl,imx6q-ahci";
++			reg = <0x02200000 0x4000>;
++			interrupts = <0 39 0x04>;
++			clocks = <&clks 154>;
++			status = "disabled";
++		};
+ 	};
+ };
+diff --git a/drivers/ata/ahci_platform.c b/drivers/ata/ahci_platform.c
+index b7078af..446ae9b 100644
+--- a/drivers/ata/ahci_platform.c
++++ b/drivers/ata/ahci_platform.c
+@@ -23,11 +23,15 @@
+ #include <linux/platform_device.h>
+ #include <linux/libata.h>
+ #include <linux/ahci_platform.h>
++#include <linux/of.h>
++#include <linux/of_device.h>
++#include <linux/of_gpio.h>
+ #include "ahci.h"
+ 
+ enum ahci_type {
+ 	AHCI,		/* standard platform ahci */
+ 	IMX53_AHCI,	/* ahci on i.mx53 */
++	IMX6Q_AHCI,	/* ahci on i.mx6q */
+ 	STRICT_AHCI,	/* delayed DMA engine start */
+ };
+ 
+@@ -39,6 +43,10 @@ static struct platform_device_id ahci_devtype[] = {
+ 		.name = "imx53-ahci",
+ 		.driver_data = IMX53_AHCI,
+ 	}, {
++	}, {
++		.name = "imx6q-ahci",
++		.driver_data = IMX53_AHCI,
++	}, {
+ 		.name = "strict-ahci",
+ 		.driver_data = STRICT_AHCI,
+ 	}, {
+@@ -75,12 +83,25 @@ static struct scsi_host_template ahci_platform_sht = {
+ 	AHCI_SHT("ahci_platform"),
+ };
+ 
++static const struct of_device_id ahci_of_match[] = {
++	{ .compatible = "calxeda,hb-ahci",  .data = &ahci_devtype[AHCI],},
++	{ .compatible = "fsl,imx6q-ahci",   .data = &ahci_devtype[IMX6Q_AHCI],},
++	{ .compatible = "snps,spear-ahci", },
++	{},
++};
++MODULE_DEVICE_TABLE(of, ahci_of_match);
++
++
+ static int __init ahci_probe(struct platform_device *pdev)
+ {
+ 	struct device *dev = &pdev->dev;
+ 	struct ahci_platform_data *pdata = dev_get_platdata(dev);
++	const struct of_device_id *of_id =
++			of_match_device(ahci_of_match, &pdev->dev);
++	const struct platform_device_id	*id_entry = of_id->data;
+ 	const struct platform_device_id *id = platform_get_device_id(pdev);
+-	struct ata_port_info pi = ahci_port_info[id ? id->driver_data : 0];
++	struct ata_port_info pi = ahci_port_info[id ? id->driver_data : \
++		id_entry->driver_data];
+ 	const struct ata_port_info *ppi[] = { &pi, NULL };
+ 	struct ahci_host_priv *hpriv;
+ 	struct ata_host *host;
+@@ -319,12 +340,6 @@ disable_unprepare_clk:
+ 
+ SIMPLE_DEV_PM_OPS(ahci_pm_ops, ahci_suspend, ahci_resume);
+ 
+-static const struct of_device_id ahci_of_match[] = {
+-	{ .compatible = "snps,spear-ahci", },
+-	{},
+-};
+-MODULE_DEVICE_TABLE(of, ahci_of_match);
+-
+ static struct platform_driver ahci_driver = {
+ 	.remove = __devexit_p(ahci_remove),
+ 	.driver = {
+-- 
+1.8.0.1
+

--- a/patches/ref_imx_v6_v7_defconfig
+++ b/patches/ref_imx_v6_v7_defconfig
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 3.7.0-rc7 Kernel Configuration
+# Linux/arm 3.7.0-rc8 Kernel Configuration
 #
 CONFIG_ARM=y
 CONFIG_SYS_SUPPORTS_APM_EMULATION=y

--- a/version.sh
+++ b/version.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 ARCH=$(uname -m)
-#DISABLE_MASTER_BRANCH=1
+DISABLE_MASTER_BRANCH=1
 
 CORES=1
 if [ "x${ARCH}" == "xx86_64" ] || [ "x${ARCH}" == "xi686" ] ; then
@@ -23,14 +23,14 @@ config="imx_v6_v7_defconfig"
 
 #Kernel/Build
 KERNEL_REL=3.7
-KERNEL_TAG=${KERNEL_REL}-rc7
+KERNEL_TAG=${KERNEL_REL}-rc8
 BUILD=imx2
 
 #v3.X-rcX + upto SHA
 #KERNEL_SHA=""
 
 #git branch
-#BRANCH="v3.7.x-imx"
+BRANCH="v3.7.x-imx"
 
 BUILDREV=1.0
 DISTRO=cross


### PR DESCRIPTION
Hello Robert,

We have been working with the sabrelite board, using your repo to build the kernel for it, and needed to add SATA support. This is a branch that adds a patch to enable SATA on the sabrlite (IMX6Q dev board).

Best,

--Allen
